### PR TITLE
Fix sentinel comment for group expanded flags

### DIFF
--- a/GN Groups.py
+++ b/GN Groups.py
@@ -1137,8 +1137,9 @@ def register_active_group_index():
             default=0
         )
     
-    # Track which groups are expanded in the hierarchy view using a different approach
-    # In Blender 4.4, BoolVectorProperty has new restrictions
+    # Individual group_expanded_0…63 properties store whether a group is expanded
+    # in the hierarchy view. group_expanded_states itself is only a sentinel so
+    # this block runs once.
     if not hasattr(bpy.types.Scene, "group_expanded_states"):
         # Criar propriedade individual para cada grupo (até 64)
         for i in range(64):
@@ -1146,6 +1147,7 @@ def register_active_group_index():
                 name=f"Group {i} Expanded",
                 default=False
             ))
+        bpy.types.Scene.group_expanded_states = True
 
 def unregister_active_group_index():
     if hasattr(bpy.types.Scene, "active_group_index"):


### PR DESCRIPTION
## Summary
- clarify how group expansion state is stored in `register_active_group_index`
- avoid re-registering expanded-state properties by marking `group_expanded_states` as True

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841108fe20883309283a29b67a08a5f